### PR TITLE
adding a web server with live code reloading on port 9000

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function (grunt) {
   
   grunt.loadNpmTasks('grunt-ts');
   grunt.loadNpmTasks('grunt-webpack');
+  grunt.loadNpmTasks('grunt-contrib-connect');
 
   grunt.initConfig({
 
@@ -208,6 +209,16 @@ module.exports = function (grunt) {
         ]
       },
       exclude: [ 'src/test/javascript/spec/e2e/*' ]
+    },
+
+    connect: {
+      server: {
+        options: {
+          port: 9000,
+          base: 'src/main/webapp',
+          livereload: true
+        }
+      }
     }
 
   });
@@ -229,6 +240,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'backJackDoItAgain',
+    'connect',
     'watch'
   ]);
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
@justawhiteguy

while `grunt-serve` seemed fine, after investigating more with the live reloading of the existing watch/compile/build steps i was doing it seemed like using `grunt-contrib-connect` was better suited because it's developed by grunt just like the watch task is.

right now when you run `grunt` all the code will be compiled and packed up, the web server will start, and a watch task will monitor file changes. when file changes are detected, the same task will execute again to compiled and pack up the code. simply refresh the browser and you're good

start the grunt task and access http://localhost:9000 to use